### PR TITLE
[SUL-75] 색상코드 모듈화

### DIFF
--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class Dark {
+  // default
+  static const black = Color(0xFF121212);
+  static const white = Color(0xFFFFFFFF);
+
+  // gray
+  static const gray050 = Color(0xFF1A1A1A);
+  static const gray100 = Color(0xFF202020);
+  static const gray200 = Color(0xFF363636);
+  static const gray300 = Color(0xFF5F5F5F);
+  static const gray400 = Color(0xFF767676);
+  static const gray500 = Color(0xFF8E8E8E);
+  static const gray600 = Color(0xFFA4A4A4);
+  static const gray700 = Color(0xFFBDBDBD);
+  static const gray800 = Color(0xFFC7C7C7);
+  static const gray900 = Color(0xFFDEDEDE);
+}
+
+class Light {
+  // default
+  static const black = Color(0xFF000000);
+  static const white = Color(0xFFFFFFFF);
+
+  // gray
+  static const gray050 = Color(0xFFF5F5F5);
+  static const gray100 = Color(0xFFDDDDDD);
+  static const gray200 = Color(0xFFC5C5C5);
+  static const gray300 = Color(0xFFADADAD);
+  static const gray400 = Color(0xFF959595);
+  static const gray500 = Color(0xFF7D7D7D);
+  static const gray600 = Color(0xFF656565);
+  static const gray700 = Color(0xFF404040);
+  static const gray800 = Color(0xFF2E2E2E);
+  static const gray900 = Color(0xFF202020);
+}
+
+


### PR DESCRIPTION
## PR 유형
- [ ] Bugfix
- [ ] Feature
- [ ] Code Formatting
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Modify Docs
- [x] Style

## 변경 사항
- [x] : gray scale 컬러 클래스 생성

![image](https://github.com/project-sulsul/SulSul-Android/assets/78401434/dec43597-4757-4e35-84c6-5c8d84259400)

## 메모
- 사용법 : 사용할 파일에서 colors.dart 임포트 → Dark.colorname or Light.colorname 형식으로 사용
